### PR TITLE
fix: add trustedSigners to nuget.config for Linux CI

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -12,4 +12,19 @@
   <config>
     <add key="signatureValidationMode" value="require" />
   </config>
+  <trustedSigners>
+    <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
+      <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+      <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+      <owners>Microsoft;microsoft.com;dotnet;aspnet;nuget;.NET Foundation;.NETFoundation</owners>
+    </repository>
+    <author name="Microsoft">
+      <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+      <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+      <certificate fingerprint="566A31882BE208BE4422F7CFD66ED09F5D4524A5994F50CCC8B05EC0528C1353" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+    </author>
+    <author name="Open XML SDK (.NET Foundation)">
+      <certificate fingerprint="BC95DB5B91A56796CB59200911559B3963B8785501AD27244437180CB79B464D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+    </author>
+  </trustedSigners>
 </configuration>


### PR DESCRIPTION
signatureValidationMode=require on Linux needs explicit trustedSigners. Adds NuGet.org repository certs, Microsoft author certs, and .NET Foundation (Open XML SDK) author cert. Build verified clean.