### PR TITLE
fix: prepare docx-review 1.5.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
@@ -44,9 +44,7 @@ jobs:
             -p:PublishSingleFile=true \
             -p:EnableCompressionInSingleFile=true \
             -p:IncludeNativeLibrariesForSelfExtract=true \
-            -p:PublishTrimmed=true \
-            -p:TrimMode=link \
-            -p:SuppressTrimAnalysisWarnings=true \
+            -p:PublishTrimmed=false \
             -o publish
 
       - name: Rename binary
@@ -63,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to docx-review are documented here.
 
+## [1.5.1] - 2026-05-06
+
+### Fixed
+- Corrected release metadata so `docx-review --version` reports the packaged release version.
+
+## [1.5.0] - 2026-04-01
+
+### Added
+- `--review` mode for automated LLM document review workflows.
+
+### Fixed
+- Linux CI package restore now uses trusted NuGet signers.
+
 ## [1.4.2] - 2026-03-09
 
 ### Added

--- a/DocxReview.csproj
+++ b/DocxReview.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <AssemblyName>docx-review</AssemblyName>
     <RootNamespace>DocxReview</RootNamespace>
-    <Version>1.4.2</Version>
+    <Version>1.5.1</Version>
     <Description>CLI tool for adding tracked changes and comments to Word documents using Open XML SDK</Description>
 
     <!-- Single-file self-contained publishing -->

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 #   make clean        # Remove build artifacts
 
 BINARY_NAME  := docx-review
-VERSION      := 1.4.2
+VERSION      := 1.5.1
 BUILD_DIR    := build
 INSTALL_DIR  := /usr/local/bin
 GH_REPO      := drpedapati/docx-review

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: docx-review
-description: "Read, edit, create, and diff Word documents (.docx) with tracked changes and comments using the docx-review CLI v1.4.2 — a .NET 8 tool built on Microsoft's Open XML SDK. Ships as a single native binary (no runtime). Use when: (1) Adding tracked changes (replace, delete, insert) to a .docx, (2) Adding or updating anchored comments to a .docx, (3) Reading/extracting text, tracked changes, comments, and metadata from a .docx, (4) Diffing two .docx files semantically, (5) Creating new documents from templates, (6) Responding to peer reviewer comments with tracked revisions, (7) Proofreading or revising manuscripts with reviewable output, (8) Any task requiring valid tracked-change .docx output with proper w:del/w:ins markup that renders natively in Word."
+description: "Read, edit, create, and diff Word documents (.docx) with tracked changes and comments using the docx-review CLI v1.5.1 — a .NET 8 tool built on Microsoft's Open XML SDK. Ships as a single native binary (no runtime). Use when: (1) Adding tracked changes (replace, delete, insert) to a .docx, (2) Adding or updating anchored comments to a .docx, (3) Reading/extracting text, tracked changes, comments, and metadata from a .docx, (4) Diffing two .docx files semantically, (5) Creating new documents from templates, (6) Responding to peer reviewer comments with tracked revisions, (7) Proofreading or revising manuscripts with reviewable output, (8) Any task requiring valid tracked-change .docx output with proper w:del/w:ins markup that renders natively in Word."
 ---
 
-# docx-review v1.4.2
+# docx-review v1.5.1
 
 CLI tool for Word document review: tracked changes, comments, read, create, diff, and git integration. Built on Microsoft's Open XML SDK — 100% compatible tracked changes and comments.
 


### PR DESCRIPTION
Fixes the stale version metadata in the v1.5.0 release path.\n\nChanges:\n- Bump DocxReview.csproj and Makefile to 1.5.1.\n- Update bundled skill and changelog.\n- Align release workflow with untrimmed publish flags and update checkout to v5.\n\nValidation:\n- make smoke passed locally; published binary reports docx-review 1.5.1.\n- Workflow YAML parses.